### PR TITLE
Fix with image middleware

### DIFF
--- a/src/withImage.ts
+++ b/src/withImage.ts
@@ -1,14 +1,14 @@
 import axios from 'axios';
-import sharp, { Sharp } from 'sharp';
+import * as sharp from 'sharp';
 import { Context, NarrowedContext } from 'telegraf';
 import { Message } from 'telegraf/typings/core/types/typegram';
 import { MountMap } from 'telegraf/typings/telegram-types';
 
 export const withImage = <T extends NarrowedContext<Context, MountMap['text']>>(
-  fn: (ctx: T, image: Sharp) => Promise<any>
+  fn: (ctx: T, image: sharp.Sharp) => Promise<any>
 ) => {
   return async (ctx: T) => {
-    let photo: Sharp | undefined;
+    let photo: sharp.Sharp | undefined;
     try {
       console.log('Got message, processing...');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "target": "ES5",
     "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
     "outDir": "./dist"
   },
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?
- [x] Bug fix
- [ ] Feature
- [ ] Other

## What is the current behavior?
### (You can also link to an open issue here)
`withImage` middleware throws an error `sharp is not function` which is caused by incorrect import of sharp module

## What is the new behavior?
`withImage` now correctly imports sharp module and it works as expected

## Does this PR introduce a breaking change?
Yes. Synthetic imports are not allowed anymore to prevent further errors connected with incorrect import.

## Other information

